### PR TITLE
Fixes #2 - ocsp.Request has no field or method Marshal

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -9,6 +9,7 @@ import (
 	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -316,7 +317,7 @@ func (e *Entry) Init() error {
 		issuerKeyHash,
 		e.serial,
 	}
-	e.request, err = ocspRequest.Marshal()
+	e.request, err = asn1.Marshal(ocspRequest)
 	if err != nil {
 		return err
 	}

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"encoding/asn1"
 	"fmt"
 	"net/http"
 	"os"
@@ -26,7 +27,7 @@ func (s *stapled) Response(r *ocsp.Request) ([]byte, bool) {
 	e := NewEntry(s.log, s.clk, s.clientTimeout, s.clientBackoff, s.entryMonitorTick)
 	e.serial = r.SerialNumber
 	var err error
-	e.request, err = r.Marshal()
+	e.request, err = asn1.Marshal(r)
 	if err != nil {
 		s.log.Err("Failed to marshal request: %s", err)
 		return nil, false


### PR DESCRIPTION
As reported in #2 it seems like the upstream `golang.org/x/crypto/ocsp`
package changed the `Request` type to no longer define a `Marshal`
method producing errors with the invocations in cache.go and server.go
respectively.

This commit takes a stab at what the intended behaviour was meant to be
and uses the `asn1` package's `Marshal` method on the `Request` object.

I might be _totally wrong_ on both the original cause of the missing `Marshal` 
method, and the intended behaviour. Feel free to reject :-) FWIW: the tests 
pass with this commit.
