### PR TITLE
Vagrant dev-env support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Ignore Vagrant local files
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.network "private_network", ip: "192.168.50.127"
+
+  config.vm.provider "virtualbox" do |vb|
+      vb.memory = "2048"
+  end
+
+  config.vm.provision "shell", path:"bootstrap/bootstrap-dev-admin.sh", privileged:true, binary: false
+
+  config.vm.provision "shell", path:"bootstrap/bootstrap-dev.sh", privileged:false, binary: false
+
+end

--- a/bootstrap/bootstrap-dev-admin.sh
+++ b/bootstrap/bootstrap-dev-admin.sh
@@ -13,12 +13,12 @@ set -e
 
 ARCH=amd64
 OS=linux
-VERSION=1.5.3
+VERSION=1.6
 
 # This should be changed when $ARCH, $OS, $VERSION are updated. If there is 
 # a SHA1 mismatch within a semantic version increase it merits investigation
 # before changing the EXPECTED_SHA1
-EXPECTED_SHA1=c5377eca4837968d043b681f00a852a262f0f5f6
+EXPECTED_SHA1=01a6a28dbe31a53103b600979bbbbd63a8104456
 
 # These should remain fixed unless Go hosting changes significantly
 GODIST=https://storage.googleapis.com/golang/

--- a/bootstrap/bootstrap-dev-admin.sh
+++ b/bootstrap/bootstrap-dev-admin.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# boostrap-dev-admin.sh is run as root by Vagrant (see Vagrantfile) during
+# provisioning. It should only do things that require root access. For non-root
+# tasks use bootstrap-dev.sh
+#
+# Responsibilities:
+#   - Downloading a fixed Go release for the dev env
+#   - Installing Go system-wide
+#   - Adding the Go installation to the system PATH
+
+set -e
+
+ARCH=amd64
+OS=linux
+VERSION=1.5.3
+
+# This should be changed when $ARCH, $OS, $VERSION are updated. If there is 
+# a SHA1 mismatch within a semantic version increase it merits investigation
+# before changing the EXPECTED_SHA1
+EXPECTED_SHA1=c5377eca4837968d043b681f00a852a262f0f5f6
+
+# These should remain fixed unless Go hosting changes significantly
+GODIST=https://storage.googleapis.com/golang/
+GOTAR=go$VERSION.$OS-$ARCH.tar.gz
+
+echo "Installing Git"
+apt-get install git -y
+
+pushd /tmp
+  echo "Downloading Go $VERSION - this may take a while!!"
+  wget $GODIST$GOTAR 2> /dev/null
+
+  echo "$EXPECTED_SHA1 $GOTAR" | sha1sum -c -
+
+  if [ $? -ne 0 ]; then
+    echo "Terminated due to sha1 mismatch. Expected: $EXPECTED_SHA1"
+    exit 1
+  fi
+
+  echo "Unpacking Go $VERSION to system"
+  tar -C /usr/local -xzf $GOTAR
+
+  echo "Adding Go to system default \$PATH"
+  echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
+  export PATH=$PATH:/usr/local/go/bin
+
+popd
+echo "Finished bootstrap-dev-admin.sh"

--- a/bootstrap/bootstrap-dev.sh
+++ b/bootstrap/bootstrap-dev.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# boostrap-dev.sh is run as the `vagrant` user by Vagrant (see Vagrantfile) during
+# provisioning. It is the non-root half of bootstrap-dev-admin.sh
+#
+# To make it convenient to develop on the host machine the `/vagrant` mount
+# shared between the host and the Vagrant VM is linked directly into the Gopath
+# on the VM. Edit locally, `vagrant ssh`, `cd` to the src directory in `~/workspace`,
+# and run `go test ./...` to test local work.
+#
+# Responsibilities:
+#   - Creating a $GOPATH
+#   - Adding $GOPATH to the environment
+#   - Adding $GOPATH's bin/ to the $PATH
+#   - Linking the Vagrant host's mountpoint into the $GOPATH
+#   - Installing godep
+#   - Vetting the stapled src, running tests, and installing it.
+
+set -e
+
+GOPATH=$HOME/workspace
+PROJECT_ROOT=$GOPATH/src/github.com/rolandshoemaker
+PROJECT=$PROJECT_ROOT/stapled
+
+echo "Creating GOPATH in $GOPATH"
+mkdir -p "$GOPATH"
+
+echo "Setting GOPATH"
+export GOPATH
+echo 'export GOPATH=$HOME/workspace' >> ~/.bashrc
+
+echo "Adding GOPATH bin/ to PATH"
+export PATH=$PATH:$GOPATH/bin
+echo 'export PATH=$PATH:$HOME/workspace/bin' >> ~/.bashrc
+
+echo "Enabling GO15VENDOREXPERIMENT"
+export GO15VENDOREXPERIMENT=1
+echo 'export GO15VENDOREXPERIMENT=1' >> ~/.bashrc
+
+echo "Creating project structure in GOPATH"
+mkdir -p "$PROJECT_ROOT"
+
+echo "Linking project src to GOPATH"
+ln -s /vagrant/ "$PROJECT"
+
+echo "Installing godep"
+go get github.com/tools/godep
+
+pushd "$PROJECT"
+  echo "Installing project"
+
+  # Uncomment when vetting passes.
+  #godep go vet ./...
+
+  go test -v ./...
+  go install ./...
+popd
+
+echo "Finished bootstrap-dev.sh"

--- a/bootstrap/bootstrap-dev.sh
+++ b/bootstrap/bootstrap-dev.sh
@@ -33,10 +33,6 @@ echo "Adding GOPATH bin/ to PATH"
 export PATH=$PATH:$GOPATH/bin
 echo 'export PATH=$PATH:$HOME/workspace/bin' >> ~/.bashrc
 
-echo "Enabling GO15VENDOREXPERIMENT"
-export GO15VENDOREXPERIMENT=1
-echo 'export GO15VENDOREXPERIMENT=1' >> ~/.bashrc
-
 echo "Creating project structure in GOPATH"
 mkdir -p "$PROJECT_ROOT"
 


### PR DESCRIPTION
This PR adds support for having a VM based dev env provisioned with Vagrant.

I've selected Ubuntu 14.04 (Trusty) as the base image, but I'm happy to change that if anyone has preferences. I think it's a good common denominator OS. Currently the VM is provisioned with 2GB of RAM

The Go version being installed is fixed at `1.5.3` and there is a hardcoded SHA1 sum in the provisioning script that the release `.tar.gz` is compared against. If there's demand for using `1.6.0` as the default I'm happy to switch this out.

Two bootstrap scripts are run during provisioning:
1. `bootstrap/bootstrap-dev-admin.sh` - invoked as root in the VM
2. `bootstrap/bootstrap-dev.sh` - invoked as `vagrant` user in the VM

The first is primarily used to install Go and set up system wide settings.

The second sets up a Go workspace, adds it to the `vagrant` user's environment, and links the project src from the host machine into the VM's gopath.

One workflow:

1.`vagrant up`
2. modify files in your local git checkout on your host machine
3. `vagrant ssh`
4. `cd workspace/src/github.com/rolandshoemaker/stapled`
5. `go test ./...`
6. etc.
