### PR TITLE
Adds `-config` parameter, fixes missing format strings.

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -17,7 +17,7 @@ func TestCache(t *testing.T) {
 
 	issuer, err := ReadCertificate("testdata/test-issuer.der")
 	if err != nil {
-		t.Fatalf("Failed to read test issuer", err)
+		t.Fatalf("Failed to read test issuer: %s", err)
 	}
 	e := &Entry{
 		mu:       new(sync.RWMutex),

--- a/certs_test.go
+++ b/certs_test.go
@@ -20,7 +20,7 @@ func TestReadCertificate(t *testing.T) {
 func TestHashNameAndPKI(t *testing.T) {
 	issuer, err := ReadCertificate("testdata/test-issuer.der")
 	if err != nil {
-		t.Fatalf("Failed to read test issuer", err)
+		t.Fatalf("Failed to read test issuer: %s", err)
 	}
 	nameHash, pkiHash, err := hashNameAndPKI(crypto.SHA1.New(), issuer.RawSubject, issuer.RawSubjectPublicKeyInfo)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,7 +12,10 @@ import (
 )
 
 func main() {
-	configFilename := "example.yaml"
+	var configFilename string
+
+	flag.StringVar(&configFilename, "config", "example.yaml", "YAML configuration file")
+	flag.Parse()
 
 	configBytes, err := ioutil.ReadFile(configFilename)
 	if err != nil {


### PR DESCRIPTION
This commit adds support for specifying a config file at runtime through a `-config` parameter. The default is set to `example.yaml` preserving the behaviour that was used beforehand.

Also tacked two quick `go vet` suggested fixes to this PR.
